### PR TITLE
Don't panic when decoding empty byte array

### DIFF
--- a/avro_encoder_decoder.go
+++ b/avro_encoder_decoder.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	avro "github.com/elodina/go-avro"
 )
 
@@ -154,7 +155,7 @@ func NewKafkaAvroDecoderAuth(url string, auth *KafkaAvroAuth) *KafkaAvroDecoder 
 }
 
 func (this *KafkaAvroDecoder) Decode(bytes []byte) (interface{}, error) {
-	if bytes == nil {
+	if bytes == nil || len(bytes) == 0 {
 		return nil, nil
 	} else {
 		if bytes[0] != 0 {


### PR DESCRIPTION
When a nil byte array is passed to Decode, the method exits without error, which is what we expect. If, however, an empty byte array is passed, the method panics.

This change updates the method so that empty byte arrays return without error.
